### PR TITLE
fix(getPreview): корректное получение расширения файла

### DIFF
--- a/org.zenframework.z8.server/src/main/java/org/zenframework/z8/server/utils/AttachmentUtils.java
+++ b/org.zenframework.z8.server/src/main/java/org/zenframework/z8/server/utils/AttachmentUtils.java
@@ -15,7 +15,7 @@ import org.zenframework.z8.server.types.file;
 public class AttachmentUtils {
 
 	static public File getPreview(file file, Map<String, String> parameters) throws IOException {
-		String ext = FileConverter.getExtension(file.baseName());
+		String ext = file.extension();
 		if (!FileConverter.isConvertableToPdf(ext))
 			return null;
 		


### PR DESCRIPTION
file.baseName() возвращает названия файла без расширения в итоге в ext попадает пустота.
file.extension() выполняет задачу получения расширения