### PR TITLE
Fixed collapser's icon in initialization state

### DIFF
--- a/org.zenframework.z8.js/src/js/dom/Dom.js
+++ b/org.zenframework.z8.js/src/js/dom/Dom.js
@@ -423,6 +423,22 @@ Z8.define('Z8.dom.Dom', {
 			return DOM.parseCls(dom.className).indexOf(cls) != -1;
 		},
 
+		findCls: function(dom, pattern) {
+			if((dom = DOM.get(dom)) == null)
+				return null;
+			var classes = DOM.parseCls(dom.className);
+			var index = -1;
+
+			for (var i = 0, length = classes.length; i < length; ++i) {
+				if (classes[i].includes(pattern)) {
+					index = i;
+					continue;
+				}
+			}
+
+			return index != -1 ? classes[index] : null;
+		},
+
 		removeCls: function(dom, cls, delay) {
 			if((dom = DOM.get(dom)) == null)
 				return;
@@ -644,10 +660,10 @@ Z8.define('Z8.dom.Dom', {
 			if(degree != 0) {
 				DOM.addCls(dom, 'fa-transform-transition');
 				DOM.addCls(dom, cls);
-				dom.rotationCls = cls;
 			} else {
-				DOM.removeCls(dom, dom.rotationCls);
-				delete dom.rotationCls;
+				var rotationCls = DOM.findCls(dom, 'fa-rotate-');
+				if (rotationCls)
+					DOM.removeCls(dom, rotationCls);
 			}
 		},
 

--- a/org.zenframework.z8.js/src/js/list/Item.js
+++ b/org.zenframework.z8.js/src/js/list/Item.js
@@ -90,10 +90,10 @@ Z8.define('Z8.list.Item', {
 		}
 
 		if(this.isTree()) {
-			var collapsed = this.isCollapsed();
-			this.rotation = collapsed ? 90 : -90;
-
-			var collapserIcon = { tag: 'i', cls: 'fa fa-caret-' + (collapsed ? 'right' : 'down') + ' icon', html: String.htmlText() };
+			var collapserCls = 'fa fa-caret-right icon';
+			if (!this.isCollapsed())
+				collapserCls += ' fa-rotate-90 fa-transform-transition';
+			var collapserIcon = { tag: 'i', cls: collapserCls, html: String.htmlText() };
 			var collapser = { tag: 'span', cls: 'collapser', cn: [collapserIcon] };
 			icons.push(collapser);
 		}
@@ -386,7 +386,7 @@ Z8.define('Z8.list.Item', {
 	collapse: function(collapsed) {
 		if(this.collapsed != collapsed) {
 			this.collapsed = collapsed;
-			DOM.rotate(this.collapserIcon, this.rotation == 90 ? (collapsed ? 0 : 90) : (collapsed ? -90 : 0));
+			DOM.rotate(this.collapserIcon, collapsed ? 0 : 90);
 			this.getList().onItemCollapse(this, collapsed);
 		}
 	},


### PR DESCRIPTION
Исправление бага, что при инициализации ListItem в зависимости от состояния collapsed создаются разные значки сворачивания (fa-caret-right или fa-caret-down). Из-за того, что они имеют разные размеры это влечёт проблемы с дизайном.