### PR TITLE
Исправление непростановки css классов filter и sort для заголовков при пользовательской фильтрации и сортировке

### DIFF
--- a/org.zenframework.z8.js/src/js/list/Header.js
+++ b/org.zenframework.z8.js/src/js/list/Header.js
@@ -168,6 +168,7 @@ Z8.define('Z8.list.Header', {
 		this.sortDirection = direction;
 		var cls = DOM.parseCls(this.getSortIcon()).pushIf('sort', 'icon');
 		DOM.setCls(this.sortElement, cls);
+		DOM.swapCls(this, direction != null, 'sort', '');
 		return cls;
 	},
 
@@ -193,6 +194,7 @@ Z8.define('Z8.list.Header', {
 		this.filtered = filtered;
 		var cls = DOM.parseCls(this.getFilterIcon()).pushIf('filter', 'icon');
 		DOM.setCls(this.filterElement, cls);
+		DOM.swapCls(this, filtered != null, 'filter', '');
 		return cls; 
 	},
 


### PR DESCRIPTION
В стандартном css есть селекторы вида
```
.air .list .header>.column.sort>.text,
.air .list .header>.column.filter>.text {
	max-width: calc(100% - 1.78571429em);
}

.air .list .header>.column.sort.filter>.text {
	max-width: calc(100% - 3.57142857em);
}
```

Данные селекторы освобождают место для значков сортировки и фильтрации в заголовках, чтобы не происходило переноса строки.

Тем не менее текущая реализация не предусматривает простановку классов .filter и .sort заголовку при пользовательском действии. Классы проставляются только при создании заголовка. Данная правка исправляет эту ситуацию