### PR TITLE
Custom HttpRequest now works correctly on retries and relogin.

### DIFF
--- a/org.zenframework.z8.js/src/js/data/HttpRequest.js
+++ b/org.zenframework.z8.js/src/js/data/HttpRequest.js
@@ -122,7 +122,7 @@ Z8.define('Z8.data.HttpRequest', {
 				Z8.callback(this.callback, response, true, this.info);
 				this.processResponse(response);
 			} else
-				HttpRequest.send({ retry: response.retry, session: response.session, server: response.server }, this.callback, this.type, this.info);
+				Z8.create(this.$className, {}).send({ retry: response.retry, session: response.session, server: response.server }, this.callback, this.type, this.info);
 		} else if(response.status == HttpRequest.status.Redirect) {
 			var redirect = response.redirect;
 			window.location.href = redirect;
@@ -158,12 +158,10 @@ Z8.define('Z8.data.HttpRequest', {
 	},
 
 	onRelogin: function() {
-		HttpRequest.send(this.data, this.callback, this.type, this.info);
+		Z8.create(this.$className, {}).send(this.data, this.callback, this.type, this.info);
 	},
 
 	encodeData: function(data) {
-		var result = [];
-
 		var isLogin = this.isLogin = data.request == 'login';
 
 		if(!isLogin)


### PR DESCRIPTION
Корректная работа системы при продвинутых случаях, когда нужно работать со своим собственным HttpRequest.
Например, есть необходимость полученный от сервера файл не передать на скачку пользователю, а как-то обработать в фоне. Для этого наследуется HttpRequest и переопределяется processResponse. Система работает корректно, но не в случае, когда запрос превышает 10 сек - тогда инициируется стандартный HttpRequest для повторной попытки.

+ убран unused code (result = [])