### PR TITLE
fix: reset row height to auto in SheetModifier.copy()

### DIFF
--- a/org.zenframework.z8.server/src/main/java/org/zenframework/z8/server/reports/poi/SheetModifier.java
+++ b/org.zenframework.z8.server/src/main/java/org/zenframework/z8/server/reports/poi/SheetModifier.java
@@ -97,6 +97,8 @@ public class SheetModifier {
 			if (targetRow == null)
 				targetRow = createRow(target.row() + i);
 
+			targetRow.setHeight((short) -1);
+
 			copyNonNull(sourceRow, source.startCol(), targetRow, target.col(), source.width());
 		}
 


### PR DESCRIPTION
Проблема: SheetModifier.copy() не сбрасывал высоту копируемых строк, из-за чего они наследовали дефолтную высоту (300) вместо авторазмера по содержимому.

Решение: добавить targetRow.setHeight((short) -1) при копировании строки — Excel будет сам вычислять высоту по содержимому.