### PR TITLE
POI: sheet multiplication and current sheet in data source

### DIFF
--- a/org.zenframework.z8.lang/src/bl/org/zenframework/z8/base/form/report/CustomData.bl
+++ b/org.zenframework.z8.lang/src/bl/org/zenframework/z8/base/form/report/CustomData.bl
@@ -4,6 +4,7 @@ import org.zenframework.z8.lang.Object;
 public class CustomData extends Object {
 
 	public int getIndex();
+	public int getSheet();
 
 	virtual public int count();
 	virtual public void open();

--- a/org.zenframework.z8.lang/src/bl/org/zenframework/z8/base/form/report/Range.bl
+++ b/org.zenframework.z8.lang/src/bl/org/zenframework/z8/base/form/report/Range.bl
@@ -13,6 +13,7 @@ public class Range extends Object {
 	//   - [subtotalsBy source.field.id()] - Field ID for grouping, subtotal inserted when field value changes
 	//   - [subotalsMerge "A1:B1,"B3:C3"] - stretch merged regions to full group length when subtotal group changes
 	//   - [merge ""A1:B1,"B3:C3"] - additional merged regions to process (static positions)
+	//   - [sheetName "Январь"] - Excel sheet name
 
 	// Records insertion axis
 	public static final int Vertical = 0;

--- a/org.zenframework.z8.server/src/main/java/org/zenframework/z8/server/base/form/report/CustomData.java
+++ b/org.zenframework.z8.server/src/main/java/org/zenframework/z8/server/base/form/report/CustomData.java
@@ -28,6 +28,11 @@ public class CustomData extends OBJECT {
 		return ((Wrapper<integer>) getMember(org.zenframework.z8.server.reports.poi.DataSource.Index).get()).get();
 	}
 
+	@SuppressWarnings("unchecked")
+	public integer z8_getSheet() {
+		return ((Wrapper<integer>) getMember(org.zenframework.z8.server.reports.poi.DataSource.Sheet).get()).get();
+	}
+
 	public integer z8_count() {
 		return new integer(0);
 	}

--- a/org.zenframework.z8.server/src/main/java/org/zenframework/z8/server/base/form/report/Range.java
+++ b/org.zenframework.z8.server/src/main/java/org/zenframework/z8/server/base/form/report/Range.java
@@ -32,6 +32,7 @@ public class Range extends OBJECT {
 	public static final String SubtotalsBy = "subtotalsBy";
 	public static final String SubtotalsMerge = "subtotalsMerge";
 	public static final String Merge = "merge";
+	public static final String SheetName = "sheetName";
 
 	// Records insertion axis
 	public static final integer Vertical = new integer(0);
@@ -79,13 +80,18 @@ public class Range extends OBJECT {
 		return getAttribute(Merge);
 	}
 
+	public String getSheetName() {
+		return getAttribute(SheetName);
+	}
+
 	public org.zenframework.z8.server.reports.poi.Range asPoiRange(Report report) {
 		report.registerDataSource(source.get());
 
 		org.zenframework.z8.server.reports.poi.Range range = new org.zenframework.z8.server.reports.poi.Range()
 				.setName(index()).setSource(source.get().get()).setBlock(getAddress()).setBoundaries(getBoundaries())
 				.setAxis(getAxis()).setAggregation(isTotals()).setSubtotalsBy(getSubtotalsBy())
-				.setSubtotalBlock(getSubtotalBlock()).setMerges(getMerge()).setSubtotalMerges(getSubtotalsMerge());
+				.setSubtotalBlock(getSubtotalBlock()).setMerges(getMerge()).setSubtotalMerges(getSubtotalsMerge())
+				.setSheetName(getSheetName());
 
 		for (Range.CLASS<Range> subrange : ranges)
 			range.addRange(subrange.get().asPoiRange(report));

--- a/org.zenframework.z8.server/src/main/java/org/zenframework/z8/server/reports/poi/DataSource.java
+++ b/org.zenframework.z8.server/src/main/java/org/zenframework/z8/server/reports/poi/DataSource.java
@@ -7,9 +7,11 @@ import org.zenframework.z8.server.types.integer;
 
 public abstract class DataSource {
 	public static final String Index = "index";
+	public static final String Sheet = "sheet";
 
 	protected Range range;
 	protected Wrapper<integer> index;
+	protected Wrapper<integer> sheet;
 	private boolean initialized = false;
 
 	public DataSource setRange(Range range) {
@@ -36,6 +38,7 @@ public abstract class DataSource {
 
 	public void open() {
 		index.set(new integer(-1));
+		sheet.set(new integer(range.getSheet()));
 	}
 
 	public boolean next() {
@@ -60,6 +63,7 @@ public abstract class DataSource {
 	protected void initialize() {
 		initialized = true;
 		index = getObjectProperty(Index);
+		sheet = getObjectProperty(Sheet);
 	}
 
 	@SuppressWarnings({ "rawtypes", "unchecked" })

--- a/org.zenframework.z8.server/src/main/java/org/zenframework/z8/server/reports/poi/PoiReport.java
+++ b/org.zenframework.z8.server/src/main/java/org/zenframework/z8/server/reports/poi/PoiReport.java
@@ -13,7 +13,10 @@ import java.util.Map;
 import org.apache.commons.io.FileUtils;
 import org.apache.poi.openxml4j.exceptions.InvalidFormatException;
 import org.apache.poi.ss.usermodel.Sheet;
+import org.apache.poi.xssf.usermodel.XSSFSheet;
 import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+import org.openxmlformats.schemas.spreadsheetml.x2006.main.CTSheetView;
+import org.openxmlformats.schemas.spreadsheetml.x2006.main.CTSheetViews;
 import org.zenframework.z8.server.base.table.value.Field;
 import org.zenframework.z8.server.db.Connection;
 import org.zenframework.z8.server.db.ConnectionManager;
@@ -29,6 +32,7 @@ import org.zenframework.z8.server.utils.IOUtils;
 public class PoiReport {
 
 	private final Map<Integer, Range> ranges = new HashMap<Integer, Range>();
+	private final Map<Integer, String> sheetNames = new HashMap<Integer, String>();
 	private final Map<Integer, Collection<Integer>> hiddenColumns = new HashMap<Integer, Collection<Integer>>();
 	private final ReportOptions options;
 
@@ -77,9 +81,12 @@ public class PoiReport {
 		Range sheetRange = ranges.get(sheet);
 
 		if (sheetRange == null)
-			ranges.put(sheet, sheetRange = new Range().setReport(this).setName("Sheet[" + sheet + ']').setSource(SimpleSource.newDefault()));
+			ranges.put(sheet, sheetRange = new Range().setReport(this).setName("Sheet[" + sheet + ']').setSheet(sheet).setSource(SimpleSource.newDefault()));
 
 		sheetRange.addRange(range);
+
+		if (range.getSheetName() != null && !sheetNames.containsKey(sheet))
+			sheetNames.put(sheet, range.getSheetName());
 
 		return this;
 	}
@@ -143,6 +150,8 @@ public class PoiReport {
 
 		XSSFWorkbook workbook = loadXlsx(outputFile);
 
+		multiplySheets(workbook);
+
 		SheetModifier sheet = new SheetModifier().setWorkbook(workbook);
 
 		try {
@@ -158,6 +167,30 @@ public class PoiReport {
 		saveXlsx(workbook, outputFile);
 
 		return outputFile;
+	}
+
+	private void multiplySheets(XSSFWorkbook workbook) {
+		int prototype = workbook.getNumberOfSheets() - 1;
+		int last = -1;
+
+		for (int sheet : ranges.keySet())
+			last = Math.max(last, sheet);
+
+		for (int sheet = prototype + 1; sheet <= last; sheet++)
+			fixSheetViews(workbook.cloneSheet(prototype));
+
+		for (Map.Entry<Integer, String> entry : sheetNames.entrySet())
+			workbook.setSheetName(entry.getKey(), entry.getValue());
+	}
+
+	private static void fixSheetViews(XSSFSheet sheet) {
+		CTSheetViews views = sheet.getCTWorksheet().getSheetViews();
+
+		if (views == null)
+			return;
+
+		for (CTSheetView view : views.getSheetViewArray())
+			view.setWorkbookViewId(view.getWorkbookViewId());
 	}
 
 	private void hideColumns(XSSFWorkbook workbook) {

--- a/org.zenframework.z8.server/src/main/java/org/zenframework/z8/server/reports/poi/Range.java
+++ b/org.zenframework.z8.server/src/main/java/org/zenframework/z8/server/reports/poi/Range.java
@@ -48,6 +48,8 @@ public class Range {
 	private Vector groupStartPosition = null;
 	private Vector lastResize = new Vector();
 	private SheetModifier.CellVisitor customVisitor = null;
+	private int sheet;
+	private String sheetName;
 
 	private final List<Range> ranges = new ArrayList<Range>();
 	private final Set<Block> subtotalMerges = new HashSet<Block>();
@@ -81,6 +83,24 @@ public class Range {
 
 	public Range setSource(DataSource source) {
 		this.source = source.setRange(this);
+		return this;
+	}
+
+	public int getSheet() {
+		return parent != null ? parent.getSheet() : sheet;
+	}
+
+	public Range setSheet(int sheet) {
+		this.sheet = sheet;
+		return this;
+	}
+
+	public String getSheetName() {
+		return sheetName;
+	}
+
+	public Range setSheetName(String sheetName) {
+		this.sheetName = sheetName;
 		return this;
 	}
 


### PR DESCRIPTION
метод fixSheetViews нужен для того, чтобы .xlsx файл после печати открывался корректно. 
Происходит из-за того, что cloneSheet() создает у клона <sheetView> без обязательного атрибута workbookViewId.
